### PR TITLE
fix: CDワークフローの.env.stagingファイル参照エラーを修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,6 @@ jobs:
       with:
         vercel-token: ${{ secrets.VERCEL_TOKEN }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        vercel-args: '--env-file=.env.staging'
         vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
         vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
         working-directory: ./


### PR DESCRIPTION
## 🔧 修正内容

CDワークフローで.env.stagingファイルが存在しないため発生していたエラーを修正しました。

### 変更点
- からを削除
- Vercelデプロイに不要な環境変数ファイル参照を除去

### 修正理由
- リポジトリに.env.stagingファイルが存在しない
- 基本的なVercelデプロイには環境変数ファイルは不要
- GitHub Secretsで環境変数を管理する方が安全

### 期待される効果
- CDワークフローが正常に動作するようになる
- ステージング環境への自動デプロイが可能になる

## 🧪 テスト
- [ ] CDワークフローが正常に実行されることを確認
- [ ] ステージング環境へのデプロイが成功することを確認

## 📋 関連Issue
- CDワークフローの失敗問題を解決

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow for staging environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->